### PR TITLE
Optional system tray icon with close-to-tray and a monitor-toggle menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15...4.0)
 project(
   MixiD
   VERSION 0.1.6
-  LANGUAGES CXX)
+  LANGUAGES C CXX)
 
 add_definitions(-DVERSION_MIXID="${MixiD_VERSION}") 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/CMake)
@@ -32,6 +32,9 @@ include_directories(${OPENGL_INCLUDE_DIRS})
 find_package(LibUSB REQUIRED)
 include_directories(${LIBUSB_INCLUDE_DIR})
 
+# optional: system tray icon (StatusNotifierItem over sd-bus)
+pkg_check_modules(SYSTEMD libsystemd)
+
 # convert data into code
 include(CMake/bin2h.cmake)
 file(GLOB_RECURSE ASSET_FILES CONFIGURE_DEPENDS Assets/*)
@@ -54,8 +57,14 @@ endforeach()
 message("Converted to C header: ${ASSET_FILES}")
 
 # Adding something we can run - Output name matches target name
-add_executable(MixiD main.cpp imgui-knobs.cpp imgui-custom.cpp)
+add_executable(MixiD main.cpp imgui-knobs.cpp imgui-custom.cpp tray.c)
 
 # Make sure you link your targets with this command. It can also link libraries and
 # even flags, so linking a target that does not exist will not give a configure-time error.
 target_link_libraries(MixiD PRIVATE imgui glfw ${OPENGL_LIBRARIES} ${LIBUSB_LIBRARIES})
+
+if (SYSTEMD_FOUND)
+	target_compile_definitions(MixiD PRIVATE HAVE_TRAY)
+	target_include_directories(MixiD PRIVATE ${SYSTEMD_INCLUDE_DIRS})
+	target_link_libraries(MixiD PRIVATE ${SYSTEMD_LIBRARIES})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,15 @@ include_directories(${OPENGL_INCLUDE_DIRS})
 find_package(LibUSB REQUIRED)
 include_directories(${LIBUSB_INCLUDE_DIR})
 
-# optional: system tray icon (StatusNotifierItem over sd-bus)
-pkg_check_modules(SYSTEMD libsystemd)
+# optional: system tray icon (StatusNotifierItem over sd-bus). basu is the
+# standalone sd-bus used on distributions that do not ship systemd.
+pkg_check_modules(SDBUS libsystemd)
+if (NOT SDBUS_FOUND)
+	pkg_check_modules(SDBUS basu)
+	if (SDBUS_FOUND)
+		set(SDBUS_IS_BASU TRUE)
+	endif()
+endif()
 
 # convert data into code
 include(CMake/bin2h.cmake)
@@ -63,8 +70,19 @@ add_executable(MixiD main.cpp imgui-knobs.cpp imgui-custom.cpp tray.c)
 # even flags, so linking a target that does not exist will not give a configure-time error.
 target_link_libraries(MixiD PRIVATE imgui glfw ${OPENGL_LIBRARIES} ${LIBUSB_LIBRARIES})
 
-if (SYSTEMD_FOUND)
+if (SDBUS_FOUND)
 	target_compile_definitions(MixiD PRIVATE HAVE_TRAY)
-	target_include_directories(MixiD PRIVATE ${SYSTEMD_INCLUDE_DIRS})
-	target_link_libraries(MixiD PRIVATE ${SYSTEMD_LIBRARIES})
+	if (SDBUS_IS_BASU)
+		target_compile_definitions(MixiD PRIVATE HAVE_BASU)
+	endif()
+	target_include_directories(MixiD PRIVATE ${SDBUS_INCLUDE_DIRS})
+	target_link_libraries(MixiD PRIVATE ${SDBUS_LIBRARIES})
+else()
+	message(STATUS "libsystemd/basu not found, building without tray support")
 endif()
+
+# Desktop entry and icon, so MixiD shows up in application menus
+include(GNUInstallDirs)
+install(TARGETS MixiD RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES Desktop/mixid.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+install(FILES Desktop/mixid.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)

--- a/Desktop/mixid.desktop
+++ b/Desktop/mixid.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=MixiD
+GenericName=Audient iD Mixer
+Comment=Control panel for Audient iD audio interfaces
+Exec=MixiD
+Icon=mixid
+Terminal=false
+Categories=AudioVideo;Audio;Mixer;
+Keywords=audient;mixer;audio;interface;soundcard;
+StartupWMClass=mixid
+SingleMainWindow=true

--- a/Desktop/mixid.svg
+++ b/Desktop/mixid.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect x="4" y="4" width="120" height="120" rx="26" fill="#171221"/>
+  <rect x="33" y="22" width="6" height="84" rx="3" fill="#4a4360"/>
+  <rect x="61" y="22" width="6" height="84" rx="3" fill="#4a4360"/>
+  <rect x="89" y="22" width="6" height="84" rx="3" fill="#4a4360"/>
+  <rect x="24" y="36" width="24" height="14" rx="5" fill="#ffffff"/>
+  <rect x="52" y="74" width="24" height="14" rx="5" fill="#8b7bff"/>
+  <rect x="80" y="54" width="24" height="14" rx="5" fill="#ffffff"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Since there is no official support by Audient for the iD interfaces on Linux, Mi
 * CMake
 * libglew-dev
 * GCC or Clang
+* libsystemd-dev, or basu on distributions without systemd (optional, enables the system tray icon)
 
 ### Compile
 * git clone the repository
@@ -40,6 +41,17 @@ Since there is no official support by Audient for the iD interfaces on Linux, Mi
 
 * Either run through sudo, or setup apropriate udev rules for your interface
 * Run the MixiD executable
+
+Optionally, `make install` also places a desktop entry and icon, so MixiD can be started from your application menu.
+
+### System tray
+
+When the desktop provides a system tray, closing the window hides MixiD there instead of quitting, so the interface stays connected and reachable.
+Clicking the icon shows and hides the window again, and right clicking it opens a menu with the monitor toggles (Dim, Alt, Talk, Phase, Mono) and Quit.
+
+This needs a StatusNotifier tray, which KDE Plasma, Cinnamon, Budgie, XFCE and LXQt provide out of the box.
+GNOME needs an appindicator extension for it, and compositors such as Sway or Hyprland need a panel that implements a tray, for example Waybar.
+Without one, or when built without libsystemd/basu, MixiD simply quits on close as before.
 
 ### udev rules
 

--- a/main.cpp
+++ b/main.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <iostream>
 #include "driver.h"
+#include "tray.h"
 
 #include "Raw_Assets.h"
 
@@ -32,6 +33,8 @@
 
 static int driver_indicator = 0;
 static bool connected = false;
+static bool tray_active = false;
+static bool force_quit = false;
 std::vector<float> levels = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f};
 static std::vector <float> bar_value;
 static std::vector <bool> phase_value;
@@ -40,6 +43,55 @@ static std::vector <bool> master_bools = {false,false,false,false,false,false};
 static void glfw_error_callback(int error, const char* description)
 {
 	fprintf(stderr, "GLFW Error %d: %s\n", error, description);
+}
+
+static GLFWwindow* window = nullptr;
+static const char* glsl_version = nullptr;
+static float main_scale = 1.0f;
+static bool want_hide = false;
+
+static void window_close_callback(GLFWwindow* win)
+{
+	// only flag it here, the window is torn down from the main loop:
+	// destroying a window inside its own callback is not safe
+	if (tray_active && !force_quit) {
+		glfwSetWindowShouldClose(win, GLFW_FALSE);
+		want_hide = true;
+	}
+}
+
+// Hiding is a full window teardown rather than glfwHideWindow(): on Wayland a
+// re-shown window does not reliably get a configured surface back, and the
+// first buffer swap then blocks forever waiting for a frame callback.
+static void window_open()
+{
+	if (window)
+		return;
+#ifdef GLFW_WAYLAND_APP_ID
+	glfwWindowHintString(GLFW_WAYLAND_APP_ID, "mixid");
+#endif
+#ifdef GLFW_X11_CLASS_NAME
+	glfwWindowHintString(GLFW_X11_CLASS_NAME, "mixid");
+	glfwWindowHintString(GLFW_X11_INSTANCE_NAME, "mixid");
+#endif
+	window = glfwCreateWindow((int)(1280 * main_scale), (int)(800 * main_scale), "MixiD - Open Source Audient mixer for Linux", nullptr, nullptr);
+	if (!window)
+		return;
+	glfwMakeContextCurrent(window);
+	glfwSwapInterval(1); // Enable vsync
+	ImGui_ImplGlfw_InitForOpenGL(window, true);
+	ImGui_ImplOpenGL3_Init(glsl_version);
+	glfwSetWindowCloseCallback(window, window_close_callback);
+}
+
+static void window_close()
+{
+	if (!window)
+		return;
+	ImGui_ImplOpenGL3_Shutdown();
+	ImGui_ImplGlfw_Shutdown();
+	glfwDestroyWindow(window);
+	window = nullptr;
 }
 
 bool toggleButton(std::string name, ImVec2 size, std::vector<bool>::reference value) {
@@ -67,42 +119,35 @@ int main(int, char**)
 	// Decide GL+GLSL versions
 #if defined(IMGUI_IMPL_OPENGL_ES2)
 	// GL ES 2.0 + GLSL 100 (WebGL 1.0)
-	const char* glsl_version = "#version 100";
+	glsl_version ="#version 100";
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 	glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
 #elif defined(IMGUI_IMPL_OPENGL_ES3)
 	// GL ES 3.0 + GLSL 300 es (WebGL 2.0)
-	const char* glsl_version = "#version 300 es";
+	glsl_version ="#version 300 es";
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 	glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
 #elif defined(__APPLE__)
 	// GL 3.2 + GLSL 150
-	const char* glsl_version = "#version 150";
+	glsl_version ="#version 150";
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 3.2+ only
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // Required on Mac
 #else
 	// GL 3.0 + GLSL 130
-	const char* glsl_version = "#version 130";
+	glsl_version ="#version 130";
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 	//glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 3.2+ only
 	//glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 3.0+ only
 #endif
 
-	// Create window with graphics context
-	float main_scale = ImGui_ImplGlfw_GetContentScaleForMonitor(glfwGetPrimaryMonitor()); // Valid on GLFW 3.3+ only
-	GLFWwindow* window = glfwCreateWindow((int)(1280 * main_scale), (int)(800 * main_scale), "MixiD - Open Source Audient mixer for Linux", nullptr, nullptr);
-	if (window == nullptr)
-		return 1;
-
+	main_scale = ImGui_ImplGlfw_GetContentScaleForMonitor(glfwGetPrimaryMonitor()); // Valid on GLFW 3.3+ only
 	int absX = 1280 * main_scale;
 	int absY = 800 * main_scale;
-	glfwMakeContextCurrent(window);
-	glfwSwapInterval(1); // Enable vsync
 
 	// Setup Dear ImGui context
 	IMGUI_CHECKVERSION();
@@ -120,12 +165,14 @@ int main(int, char**)
 	style.ScaleAllSizes(main_scale);        // Bake a fixed style scale. (until we have a solution for dynamic style scaling, changing this requires resetting Style + calling this again)
 	style.FontScaleDpi = main_scale;        // Set initial font scale. (using io.ConfigDpiScaleFonts=true makes this unnecessary. We leave both here for documentation purpose)
 
-	// Setup Platform/Renderer backends
-	ImGui_ImplGlfw_InitForOpenGL(window, true);
+	// Setup Platform/Renderer backends (window and backends are torn down and
+	// rebuilt together whenever MixiD hides to the tray)
+	window_open();
+	if (window == nullptr)
+		return 1;
 #ifdef __EMSCRIPTEN__
 	ImGui_ImplGlfw_InstallEmscriptenCallbacks(window, "#canvas");
 #endif
-	ImGui_ImplOpenGL3_Init(glsl_version);
 
 	// Load Fonts
 	style.FontSizeBase = 20.0f;
@@ -145,6 +192,10 @@ int main(int, char**)
 	bool show_another_window = false;
 	ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
 
+	//Tray icon: while one is available, closing the window hides MixiD
+	//instead of quitting (quit through Menu->Quit or the tray-less close)
+	tray_active = tray_init() != 0;
+
 	//Init all the device properties
 	setup_devices();
 	//Probe for known usb devices
@@ -161,10 +212,26 @@ int main(int, char**)
 	io.IniFilename = nullptr;
 	EMSCRIPTEN_MAINLOOP_BEGIN
 #else
-	while (!glfwWindowShouldClose(window))
+	while (!force_quit && (window == nullptr || !glfwWindowShouldClose(window)))
 #endif
 	{
 		glfwPollEvents();
+		if (tray_pump()) {
+			if (window)
+				want_hide = true;
+			else
+				window_open();
+		}
+		if (want_hide) {
+			want_hide = false;
+			window_close();
+		}
+		if (window == nullptr)
+		{
+			// hidden in the tray: no rendering, just keep the tray responsive
+			ImGui_ImplGlfw_Sleep(100);
+			continue;
+		}
 		if (glfwGetWindowAttrib(window, GLFW_ICONIFIED) != 0)
 		{
 			ImGui_ImplGlfw_Sleep(10);
@@ -193,6 +260,8 @@ int main(int, char**)
 				{
 					if (ImGui::MenuItem("Driver Select")) {show_another_window = !show_another_window;};
 					if (ImGui::MenuItem("Routing")) {show_routing = !show_routing;};
+					ImGui::Separator();
+					if (ImGui::MenuItem("Quit")) {force_quit = true; glfwSetWindowShouldClose(window, GLFW_TRUE);};
 					ImGui::EndMenu();
 				}
 
@@ -421,13 +490,12 @@ int main(int, char**)
 	EMSCRIPTEN_MAINLOOP_END;
 #endif
 
+	tray_shutdown();
 	driver_shutdown(); //just in case disconnect
-	// Cleanup
-	ImGui_ImplOpenGL3_Shutdown();
-	ImGui_ImplGlfw_Shutdown();
+	// Cleanup (window_close() is a no-op when already hidden to the tray)
+	window_close();
 	ImGui::DestroyContext();
 
-	glfwDestroyWindow(window);
 	glfwTerminate();
 
 	return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -216,11 +216,22 @@ int main(int, char**)
 #endif
 	{
 		glfwPollEvents();
-		if (tray_pump()) {
+		int tray_action = tray_pump();
+		if (tray_action == TRAY_TOGGLE) {
 			if (window)
 				want_hide = true;
 			else
 				window_open();
+		}
+		else if (tray_action == TRAY_QUIT) {
+			force_quit = true;
+		}
+		else if (tray_action >= TRAY_MASTER) {
+			int idx = tray_action - TRAY_MASTER;
+			master_bools[idx] = !master_bools[idx];
+			if (connected)
+				set_bool_state(idx);
+			tray_set_master(idx, master_bools[idx]);
 		}
 		if (want_hide) {
 			want_hide = false;
@@ -384,16 +395,16 @@ int main(int, char**)
 
 			ImGui::SetCursorPosY(absY*0.88);
 			ImGui::BeginGroup();
-			if (toggleButton("Dim", ImVec2((absX*0.2)*0.3, 40), master_bools[0])) { if (connected) {set_bool_state(0);}};
+			if (toggleButton("Dim", ImVec2((absX*0.2)*0.3, 40), master_bools[0])) { if (connected) {set_bool_state(0);} tray_set_master(0, master_bools[0]);};
 			ImGui::SameLine();
-			if (toggleButton("Alt", ImVec2((absX*0.2)*0.3, 40), master_bools[1])) { if (connected) {set_bool_state(1);}};
+			if (toggleButton("Alt", ImVec2((absX*0.2)*0.3, 40), master_bools[1])) { if (connected) {set_bool_state(1);} tray_set_master(1, master_bools[1]);};
 			ImGui::SameLine();
-			if (toggleButton("Talk", ImVec2((absX*0.2)*0.3, 40), master_bools[2])) { if (connected) {set_bool_state(2);}};
+			if (toggleButton("Talk", ImVec2((absX*0.2)*0.3, 40), master_bools[2])) { if (connected) {set_bool_state(2);} tray_set_master(2, master_bools[2]);};
 			ImGui::BeginGroup();
-			if (toggleButton("Phase", ImVec2((absX*0.2)*0.3, 40), master_bools[3])) { if (connected) {set_bool_state(3);}};
+			if (toggleButton("Phase", ImVec2((absX*0.2)*0.3, 40), master_bools[3])) { if (connected) {set_bool_state(3);} tray_set_master(3, master_bools[3]);};
 			ImGui::EndGroup();
 			ImGui::SameLine();
-			if (toggleButton("Mono", ImVec2((absX*0.2)*0.3, 40), master_bools[4])) { if (connected) {set_bool_state(4);}};
+			if (toggleButton("Mono", ImVec2((absX*0.2)*0.3, 40), master_bools[4])) { if (connected) {set_bool_state(4);} tray_set_master(4, master_bools[4]);};
 			ImGui::EndGroup();
 
 

--- a/tray.c
+++ b/tray.c
@@ -3,8 +3,9 @@
 // toolkit dependency is needed. Works out of the box on KDE and on anything
 // else with a StatusNotifier tray; when no tray watcher is running,
 // tray_init() reports failure and MixiD keeps its plain quit-on-close
-// behaviour. Any click on the icon requests a show/hide toggle, which the
-// main loop picks up through tray_pump().
+// behaviour. Clicking the icon requests a show/hide toggle and right
+// clicking opens the small com.canonical.dbusmenu menu implemented below;
+// both surface through tray_pump().
 #include "tray.h"
 
 #ifdef HAVE_TRAY
@@ -15,10 +16,18 @@
 #include <unistd.h>
 
 #define ICON_SIZE 22
+#define MENU_PATH "/MenuBar"
+
+// dbusmenu item ids (0 is reserved for the root)
+#define ITEM_TOGGLE      1
+#define ITEM_QUIT        2
+#define ITEM_SEP_TOP     3
+#define ITEM_SEP_BOTTOM  4
+#define ITEM_MASTER_BASE 10 // .. 10 + TRAY_MASTER_COUNT - 1
 
 static sd_bus *bus = NULL;
 static char busname[64];
-static int clicked = 0;
+static int pending = TRAY_NONE;
 static uint8_t icon[ICON_SIZE * ICON_SIZE * 4]; // ARGB, network byte order
 
 static void icon_rect(int x0, int y0, int w, int h, uint32_t argb)
@@ -42,6 +51,10 @@ static void icon_build(void)
   }
 }
 
+//----------------------------------------------------------------------------
+// org.kde.StatusNotifierItem
+//----------------------------------------------------------------------------
+
 static int prop_string(sd_bus *b, const char *path, const char *iface,
                        const char *prop, sd_bus_message *reply, void *userdata,
                        sd_bus_error *error)
@@ -59,6 +72,13 @@ static int prop_false(sd_bus *b, const char *path, const char *iface,
                       sd_bus_error *error)
 {
   return sd_bus_message_append(reply, "b", 0);
+}
+
+static int prop_menu(sd_bus *b, const char *path, const char *iface,
+                     const char *prop, sd_bus_message *reply, void *userdata,
+                     sd_bus_error *error)
+{
+  return sd_bus_message_append(reply, "o", MENU_PATH);
 }
 
 static int prop_pixmap(sd_bus *b, const char *path, const char *iface,
@@ -80,7 +100,7 @@ static int prop_pixmap(sd_bus *b, const char *path, const char *iface,
 
 static int method_click(sd_bus_message *m, void *userdata, sd_bus_error *error)
 {
-  clicked = 1;
+  pending = TRAY_TOGGLE;
   return sd_bus_reply_method_return(m, NULL);
 }
 
@@ -89,7 +109,7 @@ static int method_ignore(sd_bus_message *m, void *userdata, sd_bus_error *error)
   return sd_bus_reply_method_return(m, NULL);
 }
 
-static const sd_bus_vtable vtable[] = {
+static const sd_bus_vtable item_vtable[] = {
   SD_BUS_VTABLE_START(0),
   SD_BUS_PROPERTY("Category", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
   SD_BUS_PROPERTY("Id", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
@@ -98,12 +118,327 @@ static const sd_bus_vtable vtable[] = {
   SD_BUS_PROPERTY("IconName", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
   SD_BUS_PROPERTY("IconPixmap", "a(iiay)", prop_pixmap, 0, SD_BUS_VTABLE_PROPERTY_CONST),
   SD_BUS_PROPERTY("ItemIsMenu", "b", prop_false, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("Menu", "o", prop_menu, 0, SD_BUS_VTABLE_PROPERTY_CONST),
   SD_BUS_METHOD("Activate", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
   SD_BUS_METHOD("SecondaryActivate", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
-  SD_BUS_METHOD("ContextMenu", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
+  // right click is served by the dbusmenu at MENU_PATH
+  SD_BUS_METHOD("ContextMenu", "ii", "", method_ignore, SD_BUS_VTABLE_UNPRIVILEGED),
   SD_BUS_METHOD("Scroll", "is", "", method_ignore, SD_BUS_VTABLE_UNPRIVILEGED),
   SD_BUS_VTABLE_END
 };
+
+//----------------------------------------------------------------------------
+// com.canonical.dbusmenu
+//----------------------------------------------------------------------------
+
+// master is the index into the monitor toggles when the item is a checkmark,
+// -1 for a plain item
+struct menu_entry { int32_t id; const char *label; int separator; int master; };
+
+static const struct menu_entry menu[] = {
+  {ITEM_TOGGLE,          "Show / Hide", 0, -1},
+  {ITEM_SEP_TOP,         NULL,          1, -1},
+  {ITEM_MASTER_BASE + 0, "Dim",         0,  0},
+  {ITEM_MASTER_BASE + 1, "Alt",         0,  1},
+  {ITEM_MASTER_BASE + 2, "Talk",        0,  2},
+  {ITEM_MASTER_BASE + 3, "Phase",       0,  3},
+  {ITEM_MASTER_BASE + 4, "Mono",        0,  4},
+  {ITEM_SEP_BOTTOM,      NULL,          1, -1},
+  {ITEM_QUIT,            "Quit",        0, -1},
+};
+#define MENU_COUNT ((int)(sizeof(menu) / sizeof(menu[0])))
+
+static int master_state[TRAY_MASTER_COUNT];
+
+static int append_prop_s(sd_bus_message *m, const char *key, const char *val)
+{
+  int r = sd_bus_message_open_container(m, 'e', "sv");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "s", key);
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(m, 'v', "s");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "s", val);
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(m);
+  if (r < 0) return r;
+  return sd_bus_message_close_container(m);
+}
+
+static int append_prop_b(sd_bus_message *m, const char *key, int val)
+{
+  int r = sd_bus_message_open_container(m, 'e', "sv");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "s", key);
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(m, 'v', "b");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "b", val);
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(m);
+  if (r < 0) return r;
+  return sd_bus_message_close_container(m);
+}
+
+static int append_prop_i(sd_bus_message *m, const char *key, int32_t val)
+{
+  int r = sd_bus_message_open_container(m, 'e', "sv");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "s", key);
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(m, 'v', "i");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "i", val);
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(m);
+  if (r < 0) return r;
+  return sd_bus_message_close_container(m);
+}
+
+// the a{sv} property dict of a single item
+static int append_item_props(sd_bus_message *m, const struct menu_entry *e)
+{
+  int r = sd_bus_message_open_container(m, 'a', "{sv}");
+  if (r < 0) return r;
+  if (e->separator) {
+    r = append_prop_s(m, "type", "separator");
+    if (r < 0) return r;
+  }
+  else {
+    r = append_prop_s(m, "label", e->label);
+    if (r < 0) return r;
+    r = append_prop_b(m, "enabled", 1);
+    if (r < 0) return r;
+    r = append_prop_b(m, "visible", 1);
+    if (r < 0) return r;
+    if (e->master >= 0) {
+      r = append_prop_s(m, "toggle-type", "checkmark");
+      if (r < 0) return r;
+      r = append_prop_i(m, "toggle-state", master_state[e->master] ? 1 : 0);
+      if (r < 0) return r;
+    }
+  }
+  return sd_bus_message_close_container(m);
+}
+
+// one (ia{sv}av) child, wrapped in the variant the parent's av expects
+static int append_child(sd_bus_message *m, const struct menu_entry *e)
+{
+  int r = sd_bus_message_open_container(m, 'v', "(ia{sv}av)");
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(m, 'r', "ia{sv}av");
+  if (r < 0) return r;
+  r = sd_bus_message_append(m, "i", e->id);
+  if (r < 0) return r;
+  r = append_item_props(m, e);
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(m, 'a', "v"); // leaf, no children
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(m);
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(m);
+  if (r < 0) return r;
+  return sd_bus_message_close_container(m);
+}
+
+static int menu_get_layout(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  int32_t parent = 0, depth = -1;
+  int r = sd_bus_message_read(m, "ii", &parent, &depth);
+  if (r < 0) return r;
+  r = sd_bus_message_skip(m, "as"); // we always send every property
+  if (r < 0) return r;
+
+  sd_bus_message *reply = NULL;
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) return r;
+
+  r = sd_bus_message_append(reply, "u", 1u); // layout revision, never changes
+  if (r < 0) goto done;
+  r = sd_bus_message_open_container(reply, 'r', "ia{sv}av");
+  if (r < 0) goto done;
+  r = sd_bus_message_append(reply, "i", parent);
+  if (r < 0) goto done;
+  r = sd_bus_message_open_container(reply, 'a', "{sv}");
+  if (r < 0) goto done;
+  r = append_prop_s(reply, "children-display", "submenu");
+  if (r < 0) goto done;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto done;
+  r = sd_bus_message_open_container(reply, 'a', "v");
+  if (r < 0) goto done;
+  if (parent == 0 && depth != 0) {
+    for (int i = 0; i < MENU_COUNT; i++) {
+      r = append_child(reply, &menu[i]);
+      if (r < 0) goto done;
+    }
+  }
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto done;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto done;
+
+  r = sd_bus_send(NULL, reply, NULL);
+
+done:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static int menu_get_group_properties(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  // the requested id/property filters are ignored, the menu is three items
+  int r = sd_bus_message_skip(m, "aias");
+  if (r < 0) return r;
+
+  sd_bus_message *reply = NULL;
+  r = sd_bus_message_new_method_return(m, &reply);
+  if (r < 0) return r;
+
+  r = sd_bus_message_open_container(reply, 'a', "(ia{sv})");
+  if (r < 0) goto done;
+  for (int i = 0; i < MENU_COUNT; i++) {
+    r = sd_bus_message_open_container(reply, 'r', "ia{sv}");
+    if (r < 0) goto done;
+    r = sd_bus_message_append(reply, "i", menu[i].id);
+    if (r < 0) goto done;
+    r = append_item_props(reply, &menu[i]);
+    if (r < 0) goto done;
+    r = sd_bus_message_close_container(reply);
+    if (r < 0) goto done;
+  }
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) goto done;
+
+  r = sd_bus_send(NULL, reply, NULL);
+
+done:
+  sd_bus_message_unref(reply);
+  return r;
+}
+
+static int menu_get_property(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  int32_t id;
+  const char *name;
+  int r = sd_bus_message_read(m, "is", &id, &name);
+  if (r < 0) return r;
+
+  for (int i = 0; i < MENU_COUNT; i++) {
+    if (menu[i].id != id)
+      continue;
+    if (strcmp(name, "label") == 0 && menu[i].label)
+      return sd_bus_reply_method_return(m, "v", "s", menu[i].label);
+    if (strcmp(name, "type") == 0)
+      return sd_bus_reply_method_return(m, "v", "s", menu[i].separator ? "separator" : "standard");
+    if (strcmp(name, "enabled") == 0 || strcmp(name, "visible") == 0)
+      return sd_bus_reply_method_return(m, "v", "b", 1);
+    if (strcmp(name, "toggle-type") == 0 && menu[i].master >= 0)
+      return sd_bus_reply_method_return(m, "v", "s", "checkmark");
+    if (strcmp(name, "toggle-state") == 0 && menu[i].master >= 0)
+      return sd_bus_reply_method_return(m, "v", "i", master_state[menu[i].master] ? 1 : 0);
+  }
+  return sd_bus_reply_method_return(m, "v", "s", "");
+}
+
+static void menu_activate(int32_t id)
+{
+  if (id == ITEM_TOGGLE)
+    pending = TRAY_TOGGLE;
+  else if (id == ITEM_QUIT)
+    pending = TRAY_QUIT;
+  else if (id >= ITEM_MASTER_BASE && id < ITEM_MASTER_BASE + TRAY_MASTER_COUNT)
+    pending = TRAY_MASTER + (id - ITEM_MASTER_BASE);
+}
+
+static int menu_event(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  int32_t id;
+  const char *event;
+  int r = sd_bus_message_read(m, "is", &id, &event);
+  if (r < 0) return r;
+  r = sd_bus_message_skip(m, "v");
+  if (r < 0) return r;
+  r = sd_bus_message_skip(m, "u");
+  if (r < 0) return r;
+  if (strcmp(event, "clicked") == 0)
+    menu_activate(id);
+  return sd_bus_reply_method_return(m, NULL);
+}
+
+static int menu_event_group(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  int r = sd_bus_message_enter_container(m, 'a', "(isvu)");
+  if (r < 0) return r;
+  while ((r = sd_bus_message_enter_container(m, 'r', "isvu")) > 0) {
+    int32_t id;
+    const char *event;
+    if (sd_bus_message_read(m, "is", &id, &event) >= 0 &&
+        sd_bus_message_skip(m, "v") >= 0 &&
+        sd_bus_message_skip(m, "u") >= 0 &&
+        strcmp(event, "clicked") == 0)
+      menu_activate(id);
+    r = sd_bus_message_exit_container(m);
+    if (r < 0) return r;
+  }
+  if (r < 0) return r;
+  r = sd_bus_message_exit_container(m);
+  if (r < 0) return r;
+  return sd_bus_reply_method_return(m, "ai", 0);
+}
+
+static int menu_about_to_show(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  return sd_bus_reply_method_return(m, "b", 0); // layout is static
+}
+
+static int menu_about_to_show_group(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  return sd_bus_reply_method_return(m, "aiai", 0, 0);
+}
+
+static int prop_menu_version(sd_bus *b, const char *path, const char *iface,
+                             const char *prop, sd_bus_message *reply, void *userdata,
+                             sd_bus_error *error)
+{
+  return sd_bus_message_append(reply, "u", 3u);
+}
+
+static int prop_menu_string(sd_bus *b, const char *path, const char *iface,
+                            const char *prop, sd_bus_message *reply, void *userdata,
+                            sd_bus_error *error)
+{
+  return sd_bus_message_append(reply, "s",
+                               strcmp(prop, "TextDirection") == 0 ? "ltr" : "normal");
+}
+
+static int prop_menu_icon_path(sd_bus *b, const char *path, const char *iface,
+                               const char *prop, sd_bus_message *reply, void *userdata,
+                               sd_bus_error *error)
+{
+  return sd_bus_message_append(reply, "as", 0);
+}
+
+static const sd_bus_vtable menu_vtable[] = {
+  SD_BUS_VTABLE_START(0),
+  SD_BUS_PROPERTY("Version", "u", prop_menu_version, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("TextDirection", "s", prop_menu_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("Status", "s", prop_menu_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("IconThemePath", "as", prop_menu_icon_path, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_METHOD("GetLayout", "iias", "u(ia{sv}av)", menu_get_layout, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("GetGroupProperties", "aias", "a(ia{sv})", menu_get_group_properties, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("GetProperty", "is", "v", menu_get_property, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("Event", "isvu", "", menu_event, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("EventGroup", "a(isvu)", "ai", menu_event_group, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("AboutToShow", "i", "b", menu_about_to_show, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("AboutToShowGroup", "ai", "aiai", menu_about_to_show_group, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_SIGNAL("ItemsPropertiesUpdated", "a(ia{sv})a(ias)", 0),
+  SD_BUS_SIGNAL("LayoutUpdated", "ui", 0),
+  SD_BUS_SIGNAL("ItemActivationRequested", "iu", 0),
+  SD_BUS_VTABLE_END
+};
+
+//----------------------------------------------------------------------------
 
 int tray_init(void)
 {
@@ -112,7 +447,9 @@ int tray_init(void)
   icon_build();
   snprintf(busname, sizeof(busname), "org.kde.StatusNotifierItem-%d-1", (int)getpid());
   if (sd_bus_add_object_vtable(bus, NULL, "/StatusNotifierItem",
-                               "org.kde.StatusNotifierItem", vtable, NULL) < 0 ||
+                               "org.kde.StatusNotifierItem", item_vtable, NULL) < 0 ||
+      sd_bus_add_object_vtable(bus, NULL, MENU_PATH,
+                               "com.canonical.dbusmenu", menu_vtable, NULL) < 0 ||
       sd_bus_request_name(bus, busname, 0) < 0 ||
       sd_bus_call_method(bus, "org.kde.StatusNotifierWatcher",
                          "/StatusNotifierWatcher", "org.kde.StatusNotifierWatcher",
@@ -128,11 +465,55 @@ int tray_init(void)
 int tray_pump(void)
 {
   if (!bus)
-    return 0;
+    return TRAY_NONE;
   while (sd_bus_process(bus, NULL) > 0);
-  int c = clicked;
-  clicked = 0;
-  return c;
+  int p = pending;
+  pending = TRAY_NONE;
+  return p;
+}
+
+// Push a toggle's state into the menu, so a checkmark flipped in the window
+// and one flipped from the tray always agree.
+void tray_set_master(int index, int on)
+{
+  if (index < 0 || index >= TRAY_MASTER_COUNT)
+    return;
+  master_state[index] = on ? 1 : 0;
+  if (!bus)
+    return;
+
+  const struct menu_entry *entry = NULL;
+  for (int i = 0; i < MENU_COUNT; i++)
+    if (menu[i].master == index)
+      entry = &menu[i];
+  if (!entry)
+    return;
+
+  sd_bus_message *sig = NULL;
+  if (sd_bus_message_new_signal(bus, &sig, MENU_PATH, "com.canonical.dbusmenu",
+                                "ItemsPropertiesUpdated") < 0)
+    return;
+  int r = sd_bus_message_open_container(sig, 'a', "(ia{sv})");
+  if (r < 0) goto done;
+  r = sd_bus_message_open_container(sig, 'r', "ia{sv}");
+  if (r < 0) goto done;
+  r = sd_bus_message_append(sig, "i", entry->id);
+  if (r < 0) goto done;
+  r = append_item_props(sig, entry);
+  if (r < 0) goto done;
+  r = sd_bus_message_close_container(sig);
+  if (r < 0) goto done;
+  r = sd_bus_message_close_container(sig);
+  if (r < 0) goto done;
+  r = sd_bus_message_open_container(sig, 'a', "(ias)"); // nothing removed
+  if (r < 0) goto done;
+  r = sd_bus_message_close_container(sig);
+  if (r < 0) goto done;
+
+  sd_bus_send(NULL, sig, NULL);
+
+done:
+  sd_bus_message_unref(sig);
 }
 
 void tray_shutdown(void)
@@ -148,7 +529,8 @@ void tray_shutdown(void)
 #else // !HAVE_TRAY
 
 int tray_init(void) { return 0; }
-int tray_pump(void) { return 0; }
+int tray_pump(void) { return TRAY_NONE; }
+void tray_set_master(int index, int on) { (void)index; (void)on; }
 void tray_shutdown(void) {}
 
 #endif

--- a/tray.c
+++ b/tray.c
@@ -1,0 +1,154 @@
+// System tray icon for MixiD, speaking the StatusNotifierItem protocol
+// (org.kde.StatusNotifierItem) directly over D-Bus via sd-bus, so no GUI
+// toolkit dependency is needed. Works out of the box on KDE and on anything
+// else with a StatusNotifier tray; when no tray watcher is running,
+// tray_init() reports failure and MixiD keeps its plain quit-on-close
+// behaviour. Any click on the icon requests a show/hide toggle, which the
+// main loop picks up through tray_pump().
+#include "tray.h"
+
+#ifdef HAVE_TRAY
+#include <systemd/sd-bus.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define ICON_SIZE 22
+
+static sd_bus *bus = NULL;
+static char busname[64];
+static int clicked = 0;
+static uint8_t icon[ICON_SIZE * ICON_SIZE * 4]; // ARGB, network byte order
+
+static void icon_rect(int x0, int y0, int w, int h, uint32_t argb)
+{
+  for (int y = y0; y < y0 + h; y++)
+    for (int x = x0; x < x0 + w; x++) {
+      uint8_t *p = &icon[(y * ICON_SIZE + x) * 4];
+      p[0] = argb >> 24; p[1] = argb >> 16; p[2] = argb >> 8; p[3] = argb;
+    }
+}
+
+// three little faders, matching what MixiD is about
+static void icon_build(void)
+{
+  memset(icon, 0, sizeof(icon));
+  const int track_x[3] = {4, 10, 16};
+  const int cap_y[3]   = {4, 12, 8};
+  for (int i = 0; i < 3; i++) {
+    icon_rect(track_x[i], 2, 2, 18, 0xC0FFFFFF);
+    icon_rect(track_x[i] - 1, cap_y[i], 4, 5, 0xFFFFFFFF);
+  }
+}
+
+static int prop_string(sd_bus *b, const char *path, const char *iface,
+                       const char *prop, sd_bus_message *reply, void *userdata,
+                       sd_bus_error *error)
+{
+  const char *val = "";
+  if (strcmp(prop, "Category") == 0) val = "ApplicationStatus";
+  else if (strcmp(prop, "Id") == 0) val = "MixiD";
+  else if (strcmp(prop, "Title") == 0) val = "MixiD";
+  else if (strcmp(prop, "Status") == 0) val = "Active";
+  return sd_bus_message_append(reply, "s", val);
+}
+
+static int prop_false(sd_bus *b, const char *path, const char *iface,
+                      const char *prop, sd_bus_message *reply, void *userdata,
+                      sd_bus_error *error)
+{
+  return sd_bus_message_append(reply, "b", 0);
+}
+
+static int prop_pixmap(sd_bus *b, const char *path, const char *iface,
+                       const char *prop, sd_bus_message *reply, void *userdata,
+                       sd_bus_error *error)
+{
+  int r = sd_bus_message_open_container(reply, 'a', "(iiay)");
+  if (r < 0) return r;
+  r = sd_bus_message_open_container(reply, 'r', "iiay");
+  if (r < 0) return r;
+  r = sd_bus_message_append(reply, "ii", ICON_SIZE, ICON_SIZE);
+  if (r < 0) return r;
+  r = sd_bus_message_append_array(reply, 'y', icon, sizeof(icon));
+  if (r < 0) return r;
+  r = sd_bus_message_close_container(reply);
+  if (r < 0) return r;
+  return sd_bus_message_close_container(reply);
+}
+
+static int method_click(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  clicked = 1;
+  return sd_bus_reply_method_return(m, NULL);
+}
+
+static int method_ignore(sd_bus_message *m, void *userdata, sd_bus_error *error)
+{
+  return sd_bus_reply_method_return(m, NULL);
+}
+
+static const sd_bus_vtable vtable[] = {
+  SD_BUS_VTABLE_START(0),
+  SD_BUS_PROPERTY("Category", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("Id", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("Title", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("Status", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("IconName", "s", prop_string, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("IconPixmap", "a(iiay)", prop_pixmap, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_PROPERTY("ItemIsMenu", "b", prop_false, 0, SD_BUS_VTABLE_PROPERTY_CONST),
+  SD_BUS_METHOD("Activate", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("SecondaryActivate", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("ContextMenu", "ii", "", method_click, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_METHOD("Scroll", "is", "", method_ignore, SD_BUS_VTABLE_UNPRIVILEGED),
+  SD_BUS_VTABLE_END
+};
+
+int tray_init(void)
+{
+  if (sd_bus_open_user(&bus) < 0)
+    return 0;
+  icon_build();
+  snprintf(busname, sizeof(busname), "org.kde.StatusNotifierItem-%d-1", (int)getpid());
+  if (sd_bus_add_object_vtable(bus, NULL, "/StatusNotifierItem",
+                               "org.kde.StatusNotifierItem", vtable, NULL) < 0 ||
+      sd_bus_request_name(bus, busname, 0) < 0 ||
+      sd_bus_call_method(bus, "org.kde.StatusNotifierWatcher",
+                         "/StatusNotifierWatcher", "org.kde.StatusNotifierWatcher",
+                         "RegisterStatusNotifierItem", NULL, NULL, "s", busname) < 0) {
+    // no tray watcher on this desktop, caller keeps quit-on-close behaviour
+    sd_bus_unref(bus);
+    bus = NULL;
+    return 0;
+  }
+  return 1;
+}
+
+int tray_pump(void)
+{
+  if (!bus)
+    return 0;
+  while (sd_bus_process(bus, NULL) > 0);
+  int c = clicked;
+  clicked = 0;
+  return c;
+}
+
+void tray_shutdown(void)
+{
+  if (!bus)
+    return;
+  sd_bus_release_name(bus, busname);
+  sd_bus_flush(bus);
+  sd_bus_unref(bus);
+  bus = NULL;
+}
+
+#else // !HAVE_TRAY
+
+int tray_init(void) { return 0; }
+int tray_pump(void) { return 0; }
+void tray_shutdown(void) {}
+
+#endif

--- a/tray.c
+++ b/tray.c
@@ -9,7 +9,11 @@
 #include "tray.h"
 
 #ifdef HAVE_TRAY
+#ifdef HAVE_BASU
+#include <basu/sd-bus.h>
+#else
 #include <systemd/sd-bus.h>
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/tray.h
+++ b/tray.h
@@ -1,0 +1,19 @@
+#ifndef _H_TRAY_H_
+#define _H_TRAY_H_
+
+// StatusNotifierItem tray icon (see tray.c). All calls are safe no-ops when
+// built without HAVE_TRAY or when the desktop has no tray watcher running.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int tray_init(void);      // 1 if a tray icon is up, 0 if unavailable
+int tray_pump(void);      // call once per frame; 1 if the icon was clicked
+void tray_shutdown(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tray.h
+++ b/tray.h
@@ -4,12 +4,20 @@
 // StatusNotifierItem tray icon (see tray.c). All calls are safe no-ops when
 // built without HAVE_TRAY or when the desktop has no tray watcher running.
 
+#define TRAY_NONE   0
+#define TRAY_TOGGLE 1 // icon clicked, or "Show / Hide" picked from its menu
+#define TRAY_QUIT   2 // "Quit" picked from the tray menu
+#define TRAY_MASTER 16 // TRAY_MASTER + n: master toggle n picked from the menu
+
+#define TRAY_MASTER_COUNT 5 // Dim, Alt, Talk, Phase, Mono
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int tray_init(void);      // 1 if a tray icon is up, 0 if unavailable
-int tray_pump(void);      // call once per frame; 1 if the icon was clicked
+int tray_pump(void);      // call once per frame; returns a TRAY_* request
+void tray_set_master(int index, int on); // mirror a master toggle into the menu
 void tray_shutdown(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Closing the window hides MixiD to the system tray instead of quitting, so the interface stays connected and reachable. Clicking the icon shows and hides the window, and right clicking opens a menu with the monitor toggles and Quit — handy for reaching Dim or Talk without bringing the window up at all.

The whole feature is optional and degrades quietly. It compiles in when libsystemd (or basu, for distributions without systemd) is found, and at runtime `tray_init()` reports failure when the desktop has no StatusNotifier watcher, in which case the close button quits exactly as before. Nothing changes for anyone who does not have a tray.

- new `tray.c`: StatusNotifierItem plus com.canonical.dbusmenu spoken directly over sd-bus, so no GUI toolkit dependency is pulled in. The icon is drawn in code, so there is no icon file to locate at runtime
- window and menu toggles share one state, pushed back through `tray_set_master()`, which emits `ItemsPropertiesUpdated` so an open menu follows along
- hiding tears the window and both ImGui backends down and showing builds a fresh one, rather than using `glfwHideWindow()`/`glfwShowWindow()`. Those are not reliable on Wayland: a re-shown window does not always get a configured surface back and the next `glfwSwapBuffers()` then blocks forever inside `eglSwapBuffers()`, which reads as a hung application. The ImGui context, its settings and the device connection all outlive the window
- sets the Wayland app-id / X11 class to `mixid`, and installs a desktop entry and icon so MixiD appears in application menus

Testing, all on KDE Plasma with an iD24:

- Wayland and X11 (forcing the X11 backend): icon registers, repeated hide/show cycles, quit from both the window and the tray while hidden. No hangs, and fd/thread/memory counts stay flat across 16 cycles
- tray-less session (a private D-Bus session with no watcher): starts normally, registers nothing, close quits as before
- menu layout, checkmark state and the update signal verified over D-Bus against plasmashell

Two things I could not verify here and would appreciate a second pair of eyes on: the basu path (I have no non-systemd machine, though it is only a pkg-config fallback and an include switch), and GNOME-with-appindicator or Waybar, which should work as they are StatusNotifier hosts but I have not run them.

Happy to split this up, drop the desktop entry part, or put the whole thing behind a CMake option if you would rather it were opt-in.